### PR TITLE
Fix quote balancing: restore flattened curly literals in normalize_quotes + protect dialogue quotes

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1669,7 +1669,16 @@ def call_slop_fixer_llm(text_context, slop_phrase,
                     log_message(f"Thread {thread_id}: Slop fixer response appears malformed. Using original.", "WARNING")
                     return None, text_context
 
-                if rewritten_sentence.startswith('"') and rewritten_sentence.endswith('"') and len(rewritten_sentence) > 2:
+                # Only strip wrapper quotes the fixer ADDED around its rewrite.
+                # If the ORIGINAL sentence was itself a fully-quoted line of
+                # dialogue (e.g. "Get out of here!"), the LLM correctly returning
+                # it still-quoted must NOT be unwrapped here -- stripping would
+                # eat the real opening/closing quotes and is a direct source of
+                # "missing a quote on one side of dialogue".
+                _orig = text_context.strip()
+                _orig_wrapped = _orig.startswith('"') and _orig.endswith('"') and len(_orig) > 2
+                if (rewritten_sentence.startswith('"') and rewritten_sentence.endswith('"')
+                        and len(rewritten_sentence) > 2 and not _orig_wrapped):
                     rewritten_sentence = rewritten_sentence[1:-1]
 
                 if not rewritten_sentence or len(rewritten_sentence) < 0.5 * len(text_context):
@@ -1867,7 +1876,16 @@ def call_anti_slop_llm(text_context, anti_slop_phrase,
                     log_message(f"Thread {thread_id}: Anti-slop fixer response appears malformed. Using original.", "WARNING")
                     return None, text_context
 
-                if rewritten_sentence.startswith('"') and rewritten_sentence.endswith('"') and len(rewritten_sentence) > 2:
+                # Only strip wrapper quotes the fixer ADDED around its rewrite.
+                # If the ORIGINAL sentence was itself a fully-quoted line of
+                # dialogue (e.g. "Get out of here!"), the LLM correctly returning
+                # it still-quoted must NOT be unwrapped here -- stripping would
+                # eat the real opening/closing quotes and is a direct source of
+                # "missing a quote on one side of dialogue".
+                _orig = text_context.strip()
+                _orig_wrapped = _orig.startswith('"') and _orig.endswith('"') and len(_orig) > 2
+                if (rewritten_sentence.startswith('"') and rewritten_sentence.endswith('"')
+                        and len(rewritten_sentence) > 2 and not _orig_wrapped):
                     rewritten_sentence = rewritten_sentence[1:-1]
 
                 if not rewritten_sentence or len(rewritten_sentence) < 0.5 * len(text_context):

--- a/text_utils.py
+++ b/text_utils.py
@@ -76,37 +76,38 @@ def remove_markdown(text):
     return text.strip()
 
 def normalize_quotes(text):
-    if not text: return text
-    # 1. Keep your existing excessive quote collapsing...
-    text = re.sub(r'"{2,}', '"', text)
-    text = re.sub(r'"{2,}', '"', text)
-    text = re.sub(r'"{2,}', '"', text)
+    if not text:
+        return text
 
-    # 2. Replace parity logic with structural balancing
-    result = []
-    straight_open = False
-    curly_open = False
+    # 1. Collapse runs of each quote type into a single mark.
+    #    These three patterns target DIFFERENT characters: straight ("),
+    #    curly-open (U+201C) and curly-close (U+201D). They are written with
+    #    explicit \u escapes ON PURPOSE so that an editor, paste, or
+    #    "smart-quote normalizer" can't silently flatten the curly literals
+    #    back to straight quotes -- which is exactly what previously broke this
+    #    function (all three subs and the if/elif below had collapsed to the
+    #    same straight-quote glyph, so curly quotes were never balanced and the
+    #    straight branch force-appended stray quotes).
+    text = re.sub(r'"{2,}', '"', text)              # straight  "
+    text = re.sub('\u201c{2,}', '\u201c', text)     # curly open  U+201C
+    text = re.sub('\u201d{2,}', '\u201d', text)     # curly close U+201D
 
-    for char in text:
-        if char == '"':
-            if not straight_open:
-                result.append('"')
-                straight_open = True
-            else:
-                result.append('"')
-                straight_open = False
-        elif char == '"':
-            if not curly_open:
-                result.append('"')
-                curly_open = True
-            else:
-                result.append('"')
-                curly_open = False
-        else:
-            result.append(char)
+    # 2. Balance CURLY quotes by direction. Curly quotes carry their own
+    #    open/close identity, so an imbalance is unambiguous: append the missing
+    #    closers at the end, or prepend the missing openers at the start.
+    n_open = text.count('\u201c')
+    n_close = text.count('\u201d')
+    if n_open > n_close:
+        text += '\u201d' * (n_open - n_close)
+    elif n_close > n_open:
+        text = '\u201c' * (n_close - n_open) + text
 
-    # Force-close any unclosed quotes at the end
-    if straight_open: result.append('"')
-    if curly_open: result.append('"')
-
-    return "".join(result)
+    # 3. Straight quotes use the SAME glyph for open and close, so an odd count
+    #    is ambiguous -- we cannot know where the missing quote belongs. The old
+    #    code force-appended a closing " on odd parity, which produced stray
+    #    trailing quotes whenever a passage mixed straight and curly quotes
+    #    (e.g. an inch mark like 6", or a lone straight quote inside curly
+    #    dialogue). We deliberately do NOT guess here; is_incomplete_quote() plus
+    #    the regeneration retry loop are the right place to handle a genuinely
+    #    unbalanced straight quote.
+    return text


### PR DESCRIPTION
## Problem

Generated samples frequently have **mismatched dialogue quotes** — either a missing quote on one side of a line, or a stray extra quote. The quote-repair path in the anti-slop / slop flow is responsible.

## Root cause

`text_utils.normalize_quotes()` — the programmatic fallback called at the end of the quote-repair loop in `generate.py` (after the `is_incomplete_quote` retries are exhausted) — had its **curly-quote characters (U+201C / U+201D) flattened to straight ASCII `"`** at some point. An editor, a paste, or a "smart-quote normalizer" does this silently, and it gutted the intended "structural balancer":

- the three "collapse excessive quotes" `re.sub` lines were **byte-identical** (all straight `"`), so curly runs were never collapsed;
- the `if char == '"':` / `elif char == '"':` branches were the **same glyph**, so the curly branch was dead code and `curly_open` was never set.

(For contrast, `detection.py` still has intact curly literals on its `text.count(...)` lines — the flattening only hit `text_utils.py`. The `# structural balancer` comment in `generate.py` describes what the function was *meant* to do before the curlies were lost.)

This produced **both** reported symptoms from one function:

| Symptom | Mechanism |
|---|---|
| **Missing a quote on one side** | Curly dialogue (which models emit constantly) fell through to the `else` branch untouched; `curly_open` was never set, so the curly force-close never fired → unbalanced curly quotes passed straight through unfixed. |
| **Extra quote** | The straight-only parity force-close appended a stray `"` whenever the straight-quote count was odd — e.g. an inch mark (`6"`) or a lone straight quote inside curly text. |

Because the fallback then marks the sample resolved and saves it regardless, every such case landed in the output broken.

## Secondary fix — fixers eating real dialogue quotes

`call_slop_fixer_llm` and `call_anti_slop_llm` both did:

```python
if rewritten_sentence.startswith('"') and rewritten_sentence.endswith('"') and len(rewritten_sentence) > 2:
    rewritten_sentence = rewritten_sentence[1:-1]
```

This is meant to strip wrapper quotes the LLM puts around its rewrite — but a **fully-quoted line of dialogue** (`"Get out of here!"`) looks identical, so the real opening/closing quotes get stripped. That's another direct source of "missing a quote on one side of dialogue."

## Changes

**1. `normalize_quotes` rewrite (`text_utils.py`):**
- collapse runs of each quote type — straight / curly-open / curly-close — written with explicit `\u` escapes so the curly literals **can't be re-flattened** by an editor;
- balance curly quotes **by direction** (their open/close identity is unambiguous): append missing closers at the end, prepend missing openers at the start;
- **stop force-appending straight quotes** on odd parity (that was the "extras"). A straight quote is the same glyph open and close, so an odd count is ambiguous — leave it to `is_incomplete_quote()` + the regeneration retry loop rather than guess and inject a stray quote.

**2. Guard the wrapper-strip** in both fixers: only unwrap when the *original* sentence wasn't itself fully quoted, so faithfully-returned quoted dialogue keeps its quotes.

## Testing

- Both files `py_compile` clean.
- Unit-tested `normalize_quotes` on: balanced straight/curly, curly missing opener, curly missing closer, mixed curly + inch-mark (the "extras" regression), doubled-quote collapse (straight and curly), two balanced curly quotes, and empty input — all pass.
- Verified the old code produced `“tall” a 6" beam"` (stray trailing `"`) on the mixed case where the new code correctly yields `“tall” a 6" beam`.
- Confirmed zero literal curly glyphs remain in the changed files, so the fix is fully ASCII and won't silently re-break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
