### PR TITLE
Recover generation threads after an API host outage (requeue instead of drop)

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -174,6 +174,35 @@ def record_api_failure(api_slot_idx):
             API_CIRCUIT_BREAKER["is_open"][api_slot_idx] = True
             log_message(f"API Slot {api_slot_idx+1} circuit OPEN after {API_CIRCUIT_BREAKER['max_consecutive_failures']} consecutive failures. Cooling down...", "WARNING")
 
+# --- Resilience: requeue tasks that fail while their API host is down ---
+# When a host goes down the circuit breaker (above) opens for that slot. Without
+# requeueing, a worker would consume each pulled task, fail it, and discard it,
+# draining the queue so nothing is left to process when the host recovers. These
+# helpers let the worker put such tasks back, bounded so a genuinely-bad task
+# (one that fails for content reasons while the host is up) can't loop forever.
+MAX_TASK_REQUEUES = 50
+task_retry_counts = {}
+task_retry_lock = threading.Lock()
+
+def api_host_is_down(api_slot_idx):
+    """Read-only: True if this slot's circuit is currently open (host down).
+    Unlike check_circuit_breaker(), this does NOT close the circuit on cooldown."""
+    if api_slot_idx is None or api_slot_idx < 0:
+        return False
+    with api_circuit_breaker_lock:
+        return bool(API_CIRCUIT_BREAKER["is_open"].get(api_slot_idx, False))
+
+def requeue_task(q, task, task_id):
+    """Put a task back on the queue for a later retry (host-outage recovery).
+    Returns True if requeued, False once it has exhausted MAX_TASK_REQUEUES."""
+    with task_retry_lock:
+        n = task_retry_counts.get(task_id, 0) + 1
+        task_retry_counts[task_id] = n
+        if n > MAX_TASK_REQUEUES:
+            return False
+    q.put(task)
+    return True
+
 # --- Crash Recovery Functions ---
 def save_generation_state():
     """Saves the current generation state to a JSON file for potential recovery."""
@@ -556,6 +585,14 @@ def worker(thread_id, q, output_data_lock, use_questions_file_local,
 
     log_message(f"Thread {thread_id}: Worker started.", "DEBUG")
 
+    # Resilience: in non-duplication mode each worker is pinned to one API slot
+    # (thread_id % num_active_apis). Capture it up-front so we can pause -- not
+    # drain -- the queue when that host's circuit is open. -1 = duplication/unknown.
+    worker_api_slot = -1
+    if not master_duplication_enabled_local and active_enabled_api_configs_for_worker:
+        worker_api_slot = active_enabled_api_configs_for_worker[
+            thread_id % len(active_enabled_api_configs_for_worker)]['original_slot_idx']
+
     while not stop_processing:
         if check_budget_limit():
             log_message(f"Thread {thread_id}: Budget limit reached. Exiting worker.", "INFO")
@@ -615,6 +652,18 @@ def worker(thread_id, q, output_data_lock, use_questions_file_local,
                             target_processed_overall = q.processed_tasks + increment_amount
                             q.processed_tasks = min(target_processed_overall, q.total_tasks_for_progress)
                 continue
+
+        # --- Resilience gate: if this worker's API host is down (circuit open),
+        # put the task back and back off instead of consuming it. This pauses the
+        # queue during an outage so the run resumes automatically when the host
+        # returns, rather than draining (and discarding) tasks while it's down. ---
+        if worker_api_slot >= 0 and not check_circuit_breaker(worker_api_slot):
+            q.put(task)
+            q.task_done()
+            log_message(f"Thread {thread_id}: API Slot {worker_api_slot+1} down (circuit open); "
+                        f"requeued task {task_id} and backing off.", "DEBUG")
+            time.sleep(min(5.0, max(1.0, API_CIRCUIT_BREAKER['cooldown_seconds'] / 4.0)))
+            continue
 
         try:
             if stop_processing: q.task_done(); continue # Check again before intensive processing
@@ -976,7 +1025,14 @@ def worker(thread_id, q, output_data_lock, use_questions_file_local,
                         # Do NOT add to completed_task_ids - this task should not be marked complete
                     elif len(conversation_history_for_output) < (current_num_turns * 2):
                         log_message(f"Thread {thread_id}: Task {task_id} incomplete. Expected {current_num_turns * 2} messages, got {len(conversation_history_for_output)}. NOT saving to output.jsonl.", "WARNING")
-                        # Do NOT add to completed_task_ids - this task should be retried
+                        # Do NOT add to completed_task_ids - this task should be retried.
+                        # If the host is down, requeue it so it's retried once the host recovers
+                        # (otherwise it would just be discarded and lost).
+                        if api_host_is_down(worker_api_slot):
+                            if requeue_task(q, task, task_id):
+                                log_message(f"Thread {thread_id}: API Slot {worker_api_slot+1} down; requeued incomplete task {task_id} for retry.", "WARNING")
+                            else:
+                                log_message(f"Thread {thread_id}: Task {task_id} exceeded {MAX_TASK_REQUEUES} requeues; giving up.", "ERROR")
                     else:
                         with output_data_lock:
                             write_conversation(None, conversation_history_for_output, current_remove_reasoning,
@@ -994,6 +1050,13 @@ def worker(thread_id, q, output_data_lock, use_questions_file_local,
                     log_message(f"Thread {thread_id}: Processed task {task_id} (API Slot {api_slot_idx_for_this_task+1}) from file {file_name}. Turns: {len(conversation_history_for_output)//2}", "INFO")
                 else:
                     log_message(f"Thread {thread_id}: No valid conversation generated for task {task_id} (API Slot {api_slot_idx_for_this_task+1}). Not writing to output.", "WARNING")
+                    # If this failed because the host is down (circuit open), requeue it so
+                    # it's retried after the host recovers instead of being silently dropped.
+                    if api_host_is_down(worker_api_slot):
+                        if requeue_task(q, task, task_id):
+                            log_message(f"Thread {thread_id}: API Slot {worker_api_slot+1} down; requeued task {task_id} for retry.", "WARNING")
+                        else:
+                            log_message(f"Thread {thread_id}: Task {task_id} exceeded {MAX_TASK_REQUEUES} requeues; giving up.", "ERROR")
             else: # Master duplication mode - mark task complete if it went through turns
                 # Individual API outputs were already handled per turn inside the loop.
                 if conversation_history_for_output or current_llm_conversation_context: # Check if at least initial question was made


### PR DESCRIPTION
## Problem

When an API host goes down, generation **threads stall and never resume once the host comes back up** — the run is effectively dead even though the host has recovered.

## Root cause

Failed tasks are silently discarded, never requeued.

- In non-duplication ("collaborative") mode each worker is **pinned to one API slot** (`thread_id % num_apis`, generate.py worker setup) with no failover to a healthy host.
- When that host goes down, every task the worker pulls fails to generate and is **dropped**: the worker logs `No valid conversation generated… Not writing`, calls `q.task_done()`, and moves on. There is no `q.put()` to requeue it anywhere in the worker. (The incomplete-conversation branch even comments `this task should be retried` — but never actually requeues.)
- Request errors are caught (`except Timeout`, broad `except Exception`) so the **threads don't die** — they keep pulling tasks.
- After 5 consecutive failures the circuit breaker opens and the question-generation path fast-fails, which only **drains the queue faster**.
- The circuit breaker *does* auto-close after its 60s cooldown — but by then the queue is empty and every task tried during the outage is gone, so there's nothing left to process when the host returns. The recovery that exists is moot because the work was already thrown away.

## Fix

Pause the queue during an outage instead of draining it.

1. **Resilience gate** at the top of the worker loop: if this worker's API slot circuit is open, put the task back (`q.put`) and back off, so tasks **accumulate** while the host is down and get processed when it recovers. `check_circuit_breaker()` is used here so the 60s cooldown can still close the circuit.
2. **Requeue on failure while the host is down**, bounded by `MAX_TASK_REQUEUES`, at both non-duplication failure points (incomplete conversation / no valid conversation) — so the in-flight tasks that tripped the breaker aren't lost either.
3. `api_host_is_down()` — a read-only circuit check used at the failure points (it does **not** reset the cooldown, unlike `check_circuit_breaker()`).

The `MAX_TASK_REQUEUES` cap means a genuinely-bad task (one that fails for *content* reasons while the host is up) still can't loop forever — those aren't requeued at all, since `api_host_is_down()` is false when the host is healthy.

## Scope

Only affects **non-duplication mode**. In duplication mode `worker_api_slot` stays `-1`, so the gate and the requeue are no-ops and behavior is unchanged.

## Testing

- `generate.py` compiles clean.
- Queue simulation of the gate + requeue primitive (real `queue.Queue`, 4 workers, 25 tasks, host down then recovered): during the outage all 25 tasks stay pending and 0 are processed (queue paused, nothing lost); after recovery `q.join()` completes with all 25 processed exactly once — no deadlock, no loss, `task_done` balance preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
